### PR TITLE
Fixup todo_thunk example

### DIFF
--- a/examples/todo_thunk.py
+++ b/examples/todo_thunk.py
@@ -57,11 +57,11 @@ def todo_app(state, action):
         return state
 
 
-@types.coroutine
+@asyncio.coroutine
 def run():
     thunk_middleware = aioredux.middleware.thunk_middleware
-    create_store_with_middleware = aioredux.apply_middleware(thunk_middleware)(aioredux.Store)
-    store = create_store_with_middleware(todo_app, initial_state)
+    create_store_with_middleware = aioredux.apply_middleware(thunk_middleware)(aioredux.core.Store)
+    store = yield from create_store_with_middleware(todo_app, initial_state)
 
     store.subscribe(lambda: logging.info("new state: {}".format(store.state)))
     store.dispatch(fetch_todo())

--- a/examples/todo_thunk.py
+++ b/examples/todo_thunk.py
@@ -70,9 +70,9 @@ def run():
     store.subscribe(lambda: logging.info("new state: {}".format(store.state)))
     store.dispatch(fetch_todo())
     for i in range(5):
-        store.dispatch(add_todo('do task {}'.format(i)))
-    store.dispatch(complete_todo(1))
-    store.dispatch(complete_todo(2))
+        yield from store.dispatch(add_todo('do task {}'.format(i)))
+    yield from store.dispatch(complete_todo(1))
+    yield from store.dispatch(complete_todo(2))
     logging.info('Finished')
 
 if __name__ == '__main__':

--- a/examples/todo_thunk.py
+++ b/examples/todo_thunk.py
@@ -38,8 +38,9 @@ def fetch_todo():
 
     See https://rackt.github.io/redux/docs/advanced/AsyncActions.html
     '''
+    @coroutine
     def thunk(dispatch, state_func=None):
-        dispatch(add_todo('do task x (from thunk)'))
+        yield from dispatch(add_todo('do task x (from thunk)'))
     return thunk
 
 
@@ -68,7 +69,7 @@ def run():
     store = yield from create_store_with_middleware(todo_app, initial_state)
 
     store.subscribe(lambda: logging.info("new state: {}".format(store.state)))
-    store.dispatch(fetch_todo())
+    yield from store.dispatch(fetch_todo())
     for i in range(5):
         yield from store.dispatch(add_todo('do task {}'.format(i)))
     yield from store.dispatch(complete_todo(1))

--- a/examples/todo_thunk.py
+++ b/examples/todo_thunk.py
@@ -2,8 +2,12 @@ import asyncio
 import enum
 import logging
 import types
-
 import toolz
+
+try:
+    from types import coroutine
+except ImportError:
+    from asyncio import coroutine
 
 import aioredux
 import aioredux.middleware
@@ -57,10 +61,10 @@ def todo_app(state, action):
         return state
 
 
-@asyncio.coroutine
+@coroutine
 def run():
     thunk_middleware = aioredux.middleware.thunk_middleware
-    create_store_with_middleware = aioredux.apply_middleware(thunk_middleware)(aioredux.core.Store)
+    create_store_with_middleware = aioredux.apply_middleware(thunk_middleware)(aioredux.create_store)
     store = yield from create_store_with_middleware(todo_app, initial_state)
 
     store.subscribe(lambda: logging.info("new state: {}".format(store.state)))


### PR DESCRIPTION
Hey, I can't get that to run. I am on Python 3.4. I tried to fix up the initial errors. Now I am getting:

```
Traceback (most recent call last):
  File "todo_thunk.py", line 78, in <module>
    loop.run_until_complete(run())
  File "/usr/lib/python3.4/asyncio/base_events.py", line 316, in run_until_complete
    return future.result()
  File "/usr/lib/python3.4/asyncio/futures.py", line 275, in result
    raise self._exception
  File "/usr/lib/python3.4/asyncio/tasks.py", line 238, in _step
    result = next(coro)
  File "todo_thunk.py", line 64, in run
    store = yield from create_store_with_middleware(todo_app, initial_state)
  File "/home/kaspar/.local/lib/python3.4/site-packages/aioredux/utils.py", line 16, in create_store
    store = yield from next_handler(reducer, initial_state)
TypeError: 'Store' object is not iterable
```